### PR TITLE
Update get-token.sh script with latest token exchange flow on EDB Cloud authentication system

### DIFF
--- a/azure/create-spn.sh
+++ b/azure/create-spn.sh
@@ -1,5 +1,24 @@
 #!/bin/bash
-
+#
+# This script is used to create a SPN(Service Principal Name) with enough
+# permissions in your Azure subscription for handling the EDB Cloud managed
+# service.
+#
+# What it does:
+#   - assume you have already login to your Azure AD(Active Directory) directory by Azure CLI
+#   - set your Azure CLI context to the given subscription
+#   - create a new client app in the Azure AD directory
+#   - assign this client app the role of "ower" of the given subscription
+#
+# it finally outputs the:
+#   - client app Id
+#   - client app secret
+#   - your Azure subscription Id
+# These outputs will be used in the EDB Cloud Signup submission form.
+#
+# For more details, please refer to
+#  https://www.enterprisedb.com/docs/edbcloud/latest/getting_started/02_connect_cloud_account
+#
 set -e
 
 display_name=""

--- a/azure/resource-quotas.sh
+++ b/azure/resource-quotas.sh
@@ -1,4 +1,28 @@
 #!/bin/bash
+#
+# This script is used as a prerequisite check to tell you if the given location
+# in your Azure subscription can meet the requirement for EDB Cloud to create the
+# PostgreSQL cluster in.
+#
+# Given one the below input:
+#   - location
+#   - PostgreSQL cluster's type (only support Azure ESv3 series)
+#   - whether the HA (High Availability) is used for the PostgreSQL cluster
+#   - network type (private, or public)
+# it checks the below requirement in the location:
+#   - if there is enough Virtual Machine quota left for this PostgreSQL cluster type
+#     in your Azure subscription
+#   - if there is enough SKU(Stock Keeping Unit) left in that region for your PostgreSQL
+#     cluster's type (of the Virtual Machine)
+#   - if there is enough IP left to expose the service for you to access the
+#     PostgreSQL cluster
+#
+# The output of this script tells any unsatisfied condition and report in the form
+# of table.
+#
+# For more details, please refer to:
+#  https://www.enterprisedb.com/docs/edbcloud/latest/getting_started/01_check_resource_limits/#increasing-network-quota
+#
 set -e
 
 function show_help()


### PR DESCRIPTION
This PR:

- Update `get-token.sh` script with latest token exchange flow on EDB Cloud authentication system
- Disable to output the `id_token` in `get-token.sh` as EDB Cloud does not use it at the moment.
- Update all the scripts with a rich comments inside for the reader to understand what this script is about.  