### PR TITLE
rename resource-quotas.sh to azure-preflight.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ where the scripts provided in this repository are used:
 
 ### Check Azure subscription readiness for running EDB Cloud
 
-[resource-quotas.sh](./azure/resource-quotas.sh) is a script used to check the
+[azure-preflight.sh](./azure/azure-preflight.sh) is a script used to check the
 Azure subscription readiness for running the EDB Cloud by:
 - calculating if the Azure resource quota in your Azure subscription can meet
  the requirement of the EDB Cloud?

--- a/azure/azure-preflight.sh
+++ b/azure/azure-preflight.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# This script is used as a prerequisite check to tell you if the given location
+# This script is used as a preflight check to tell if the given location
 # in your Azure subscription can meet the requirement for EDB Cloud to create the
 # PostgreSQL cluster in.
 #
@@ -199,6 +199,7 @@ TMP_NW_OUTPUT=$TMPDIR/ip_$$
 TMP_SKU_OUTPUT=$TMPDIR/sku_$$
 TMP_PROVIDER_OUTPUT=$TMPDIR/provider_$$
 TMP_SUGGESTION=$TMPDIR/suggestions_$$
+touch $TMP_SUGGESTION
 
 function suggest()
 {


### PR DESCRIPTION
the `resource-quotas.sh` is now extended to check more than just Azure resource limitation on quota in one azure subscription. 

It should be renamed to `azure-preflight.sh` at the moment.