### PR TITLE
update get-token.sh to support new free trial user login experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ IAM Trust Policy applied to the created IAM role here:
 [2]: https://portal.biganimal.com/api/docs/
 [3]: https://stedolan.github.io/jq/
 [4]: https://docs.microsoft.com/en-us/cli/azure/
-[5]: https://www.enterprisedb.com/docs/biganimal/latest/reference
+[5]: https://www.enterprisedb.com/docs/biganimal/latest/reference/api/
 [6]: https://aws.amazon.com/cli/
 [7]: https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/

--- a/api/get-token.sh
+++ b/api/get-token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2021 EnterpriseDB Corporation
+# Copyright 2021,2022 EnterpriseDB Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,14 +36,15 @@ function show_help()
     echo "Usage:"
     echo "  $0 [flags] [options]"
     echo ""
-    echo "      -o, --format  json | plain         [optional] output format, default 'json'"
-    echo "      -r, --refresh <refresh_token>      [optional] query for tokens again by the given refresh_token"
-    echo "                                         this revokes and rotates the given refresh token, "
-    echo "                                         please remember the newly returned refresh_token for"
-    echo "                                         the next use"
-    echo "      -h, --help                         show this help message"
+    echo "      -ft, --freetrial                   [optional] login with BigAnimal free trial account"
+    echo "      -o,  --format  json | plain        [optional] output format, default 'json'"
+    echo "      -r,  --refresh <refresh_token>     [optional] query for tokens again by the given refresh_token"
+    echo "                                           this revokes and rotates the given refresh token, "
+    echo "                                           please remember the newly returned refresh_token for"
+    echo "                                           the next use"
+    echo "      -h,  --help                         show this help message"
     echo ""
-    echo "Reference: https://www.enterprisedb.com/docs/biganimal/latest/reference/ "
+    echo "Reference: https://www.enterprisedb.com/docs/biganimal/latest/reference/api/ "
     echo ""
 }
 
@@ -54,19 +55,24 @@ function check()
 
     # format can only be plain or json
     AVAILABLE_FORMAT=(
-	plain
+	      plain
         json
     )
     [[ ! " ${AVAILABLE_FORMAT[@]}" =~ "${format}" ]] && show_help && echo "error: invalid format" && exit 1
 }
 
 format="json"
+freetrial=false
 # argument handling
 POSITIONAL=()
 while [[ $# -gt 0 ]]; do
   key="$1"
 
   case $key in
+    -ft|--freetrial)
+      freetrial=true
+      shift 1
+      ;;
     -o|--format)
       format="$2"
       shift 2
@@ -94,12 +100,17 @@ curl -s ${BASE_URL}/api/v1/auth/provider > provider_resp || cat provider_resp ||
 # response sample
 # {
 #   "clientId": "pM8PRguGtW9yVnrsvrvpaPyyeS9fVvFh",
+#   "freetrialClientId": "m71bEVZrGsWiKtPqMI3hYCHCG3EYLPDk",
 #   "issuerUri": "https://auth.biganimal.com",
 #   "scope": "openid profile email offline_access",
 #   "audience": "https://portal.biganimal.com/api"
 # }
 
-CLIENT_ID=$(< provider_resp jq -r .clientId)
+if [ "$freetrial" = 'true' ]; then
+  CLIENT_ID=$(< provider_resp jq -r .freetrialClientId)
+else
+  CLIENT_ID=$(< provider_resp jq -r .clientId)
+fi
 AUTH_SERVER=$(< provider_resp jq -r .issuerUri)
 SCOPE=$(< provider_resp jq -r .scope)
 AUDIENCE=$(< provider_resp jq -r .audience)


### PR DESCRIPTION
the free trial user now owns one new dedicated client application to use to finish the OAuth2 device-flow authentication.
This PR is to support that. 

The old client ID is still available at this moment.