### PR TITLE
fix(UPM-6796): fixed flags"--policy-name-suffix" and "--role-name-suf…

### DIFF
--- a/aws/biganimal-csp-setup
+++ b/aws/biganimal-csp-setup
@@ -214,11 +214,11 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     -p|--policy-name-suffix)
-      policy_name="$2"
+      suffix_policy_name="$2"
       shift 2
       ;;
     -r|--role-name-suffix)
-      role_name="$2"
+      suffix_role_name="$2"
       shift 2
       ;;
     -q|--increase-quotas)


### PR DESCRIPTION
to pass --policy-name-suffix to setup-csp script is not working, always create policy with name biganimal-policy 

--role-name-suffix is the same as 

