### PR TITLE
adding regions Azure centralindia and AWS Mumbai (ap-south-1)

### DIFF
--- a/aws/biganimal-csp-preflight
+++ b/aws/biganimal-csp-preflight
@@ -104,6 +104,7 @@ AVAILABLE_REGIONS=(
   ap-northeast-2
   ap-northeast-1
   ap-southeast-1
+  ap-south-1
   us-east-1
   us-east-2
   us-west-2

--- a/azure/biganimal-csp-preflight
+++ b/azure/biganimal-csp-preflight
@@ -107,6 +107,7 @@ AVAILABLE_REGIONS=(
     australiaeast
     brazilsouth
     canadacentral
+    centralindia
     centralus
     eastus
     eastus2


### PR DESCRIPTION
This PR adds regions Azure centralindia and AWS Mumbai (ap-south-1)
