### PR TITLE
Update README.md and azure-csp-setup script to tell wget is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains utilities and scripts to help on using [BigAnimal][1]
 The below software utilities are required to be installed on the machine
 where the scripts provided in this repository are used:
 
+- [wget][9]
 - [jq][3]
 - [azure cli][4] v2.26 or above (if runs against Azure)
 - [aws-cli][6] v.2.3.0 or above (if runs against AWS)
@@ -72,3 +73,5 @@ For more details about BigAnimal API, please refer to [Using the BigAnimal API][
 [6]: https://aws.amazon.com/cli/
 [7]: https://www.enterprisedb.com/docs/biganimal/latest/reference/cli/
 [8]: https://formulae.brew.sh/formula/bash
+[9]: https://www.gnu.org/software/wget/
+

--- a/azure/biganimal-csp-setup
+++ b/azure/biganimal-csp-setup
@@ -72,7 +72,7 @@ show_help()
 
 check()
 {
-  # jq is required.
+  # jq, wget are required.
   hash jq > /dev/null 2>&1 || { show_help; suggest "Error: please install jq on the system" alert; }
   hash wget > /dev/null 2>&1 || { show_help; suggest "Error: please install wget on the system" alert; }
   check_az_version

--- a/azure/biganimal-csp-setup
+++ b/azure/biganimal-csp-setup
@@ -57,6 +57,7 @@ show_help()
   echo "  Microsoft.Authorization/roleAssignments/write"
   echo "Required tools:"
   echo "  jq"
+  echo "  wget"
   echo "Usage:"
   echo "  $0 -d NAME -s SUBSCRIPTION_ID [-i CLIENT_ID] [options]"
   echo ""
@@ -73,6 +74,7 @@ check()
 {
   # jq is required.
   hash jq > /dev/null 2>&1 || { show_help; suggest "Error: please install jq on the system" alert; }
+  hash wget > /dev/null 2>&1 || { show_help; suggest "Error: please install wget on the system" alert; }
   check_az_version
   check_display_name
   check_subscription


### PR DESCRIPTION
The `wget` is by default not installed on mac system. This PR is to mention the `wget` is needed as well like `jq` for `azure-csp-setup` script.