### PR TITLE
chore(UPM-12468): Add shebang to the database name change script

### DIFF
--- a/utils/superset/README.md
+++ b/utils/superset/README.md
@@ -12,11 +12,16 @@ Requires user to pass the database_name (which should be present in his/her envi
 
 # Run Command
 
-    python3 db_name_change.py <database_name> -i <input_file> -o <output_file>
-    e.g.
-    python3 db_name_change.py edb -i utils/superset/pgd_monitoring_template.json  -o utils/superset/upload.json
+    cd cloud-utilities/utils/superset
+    chmod +x db_name_change.py
+    ./db_name_change.py <database_name> -i pgd_monitoring_template.json -o <output_file>
+
+e.g.
+
+    ./db_name_change.py edb -i pgd_monitoring_template.json  -o utils/superset/upload.json
  
 # Usage
+    ./db_name_change.py -h
     usage: db_name_change.py [-h] [-i INPUT_FILE] [-o OUTPUT_FILE] database_name
 
     positional arguments:

--- a/utils/superset/db_name_change.py
+++ b/utils/superset/db_name_change.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """
 This script will generate the upload JSON for the entered database name.
 """


### PR DESCRIPTION
# Pull Request

## What

Add shebang in the python script.

## Why

The current python script to change the database name needs an explicit call to `python3`. With the shebang line and making the script executable, we'd be getting rid of `python3 script name and simply executing the script `./script-name`

## How

Add a shebang line in the script and relevant changes in the README.

## Test

Tested locally.

## Context

_Provide a bulleted list of GitHub issues, or any other references (mailing list discussion, etc...) that reviewers can reference
for additional information regarding scope of the pull request._
