### PR TITLE
fix: GCP setup can handle multiple keys in the same SA

### DIFF
--- a/gcp/biganimal-csp-setup
+++ b/gcp/biganimal-csp-setup
@@ -246,18 +246,26 @@ create_service_account()
   # checking if the service account is having a key
   sa_key_exists=$(gcloud iam service-accounts keys list --project "$project" \
     --iam-account "${service_account_id}" --managed-by user --format json | jq '. | length')
-  if [ "$sa_key_exists" -eq 0 ]; then
-    # the service account is not having any key, going to create it
+  if [ "$sa_key_exists" -lt 2 ]; then
+    # the service account is either not having any key or having only one, going to create a new one
     echo -e "Creating a GCP service account ${GREEN}biganimal-${suffix_sa_name}${NC} key within the GCP project ${GREEN}${project}${NC}..."
     gcloud iam service-accounts keys create "${CURRENT_PATH}"/biganimal_serviceaccount_key.json \
       --iam-account "${service_account_id}" --format json > "${TMPDIR}"/biganimal_createsakey_output.json
   else
-    # the service account is already having a key, nothing to do
-    echo -e "The GCP service account ${GREEN}biganimal-${suffix_sa_name}${NC} already has a key within the GCP project ${GREEN}${project}${NC}!"
+    # the service account is already having 2 or more keys, deleting the oldest one and creating a new one
+    echo -e "The GCP service account ${GREEN}biganimal-${suffix_sa_name}${NC} already has a few keys within the GCP project ${GREEN}${project}${NC}!"
+    echo -e "Deleting the oldest GCP service account ${GREEN}biganimal-${suffix_sa_name}${NC} key within the GCP project ${GREEN}${project}${NC}..."
+    sa_oldest_key=$(gcloud iam service-accounts keys list --project "$project" \
+      --iam-account "${service_account_id}" --managed-by user --format json | jq -r 'sort_by(.validAfterTime) | .[0].name')
+    sa_oldest_key_id=${sa_oldest_key##*/}
+    gcloud iam service-accounts keys delete "$sa_oldest_key_id" --iam-account "${service_account_id}" --quiet > "${TMPDIR}"/biganimal_deletesakey_output.json
+    echo -e "Creating a GCP service account ${GREEN}biganimal-${suffix_sa_name}${NC} key within the GCP project ${GREEN}${project}${NC}..."
+    gcloud iam service-accounts keys create "${CURRENT_PATH}"/biganimal_serviceaccount_key.json \
+      --iam-account "${service_account_id}" --format json > "${TMPDIR}"/biganimal_createsakey_output.json
   fi
-  # getting the service account key id
+  # getting the newest service account key id
   sa_key_id=$(gcloud iam service-accounts keys list --project "$project" \
-    --iam-account "${service_account_id}" --managed-by user --format json | jq -r '.[0].name')
+    --iam-account "${service_account_id}" --managed-by user --format json | jq -r 'sort_by(.validAfterTime) | reverse | .[0].name')
   # getting the escaped JSON string of the key to be saved later into "ba-passport.json"
   sa_key=$(base64 -w0 < "${CURRENT_PATH}"/biganimal_serviceaccount_key.json)
 }


### PR DESCRIPTION
when the GCP SA is having less than 2 keys:

```
gcp/biganimal-csp-setup -p <GCP_PROJECT_ID> -s "sa-test" -r "role_test"
Run GCP CSP setup with gcloud cli 439.0.0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17242  100 17242    0     0  57628      0 --:--:-- --:--:-- --:--:-- 58646
Downloaded /Users/valeriodelsarto/Git/cloud-utilities/biganimal_GCP_baserole.yaml
Updating GCP custom role biganimal_role_test within GCP project <GCP_PROJECT_ID>...
GCP service account biganimal-sa-test already exists within GCP project <GCP_PROJECT_ID>...
Allowing GCP service account biganimal-sa-test to use the GCP project <GCP_PROJECT_ID>...
Updated IAM policy for project [<GCP_PROJECT_ID>].
Creating a GCP service account biganimal-sa-test key within the GCP project <GCP_PROJECT_ID>...
created key [24e00f0919ab177e221bb12b1d6d015f603f9d0b] of type [json] as [/Users/valeriodelsarto/Git/cloud-utilities/biganimal_serviceaccount_key.json] for [biganimal-sa-test@<GCP_PROJECT_ID>.iam.gserviceaccount.com]

######################################################
# Script Results running on GCP project <GCP_PROJECT_ID> #
######################################################

Created GCP custom role biganimal_role_test
Created GCP service account biganimal-sa-test
Created GCP service account key, ID is 24e00f0919ab177e221bb12b1d6d015f603f9d0b
```

when the GCP SA is already having 2 keys:

```
gcp/biganimal-csp-setup -p <GCP_PROJECT_ID> -s "sa-test" -r "role_test"
Run GCP CSP setup with gcloud cli 439.0.0
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17242  100 17242    0     0  72976      0 --:--:-- --:--:-- --:--:-- 74965
Downloaded /Users/valeriodelsarto/Git/cloud-utilities/biganimal_GCP_baserole.yaml
Updating GCP custom role biganimal_role_test within GCP project <GCP_PROJECT_ID>...
GCP service account biganimal-sa-test already exists within GCP project <GCP_PROJECT_ID>...
Allowing GCP service account biganimal-sa-test to use the GCP project <GCP_PROJECT_ID>...
Updated IAM policy for project [<GCP_PROJECT_ID>].
The GCP service account biganimal-sa-test already has a few keys within the GCP project <GCP_PROJECT_ID>!
Deleting the oldest GCP service account biganimal-sa-test key within the GCP project <GCP_PROJECT_ID>...
deleted key [ee0e2a4b955246c09c4857482a4d77eb76f4ebf0] for service account [biganimal-sa-test@<GCP_PROJECT_ID>.iam.gserviceaccount.com]
Creating a GCP service account biganimal-sa-test key within the GCP project <GCP_PROJECT_ID>...
created key [b6d1f051725669198b8927967a7deb4741559e9e] of type [json] as [/Users/valeriodelsarto/Git/cloud-utilities/biganimal_serviceaccount_key.json] for [biganimal-sa-test@<GCP_PROJECT_ID>.iam.gserviceaccount.com]

######################################################
# Script Results running on GCP project <GCP_PROJECT_ID> #
######################################################

Created GCP custom role biganimal_role_test
Created GCP service account biganimal-sa-test
Created GCP service account key, ID is b6d1f051725669198b8927967a7deb4741559e9e
``` 