### PR TITLE
fix: Adding 'SG rules per SG' quota suggestion for EHA on AWS

### DIFF
--- a/aws/biganimal-csp-preflight
+++ b/aws/biganimal-csp-preflight
@@ -527,6 +527,11 @@ vpc_quota_code=( "L-F678F1CE" "VPCs per Region" )
 vpc_quota=$(aws service-quotas get-service-quota --region "$region" --service-code vpc --quota-code "${vpc_quota_code[0]}" --query 'Quota.Value' --no-cli-pager)
 nlb_quota_code=( "L-69A177A2" "Network Load Balancers per Region" )
 nlb_quota=$(aws service-quotas get-service-quota --region "$region" --service-code elasticloadbalancing --quota-code "${nlb_quota_code[0]}" --query 'Quota.Value' --no-cli-pager)
+sgrules_quota_code=( "L-0EA8095F" "Inbound or outbound rules per security group" )
+sgrules_quota=$(aws service-quotas get-service-quota --region "$region" --service-code vpc --quota-code "${sgrules_quota_code[0]}" --query 'Quota.Value' --no-cli-pager)
+
+# on eha we suggest to increase the VPC limit "Inbound or outbound rules per security group" to at least 200
+[ "$architecture" = "eha" ] && [ "${sgrules_quota%.*}" -lt "200" ] && store_suggestion "Highly recommended for EHA: '${GREEN}${sgrules_quota_code[1]}${NC}' quota in '${GREEN}$region${NC}' needs to be increased to '${RED}200${NC}'"
 
 # calculate required resources
 need_mgmt_vcpus=$(infra_vcpus)


### PR DESCRIPTION
```bash
$ bash aws/biganimal-csp-preflight -i r5.16xlarge -x eha -e public -r --onboard <AWS_ACCOUNT_ID> us-east-1
Run AWS Preflight Checks with aws-cli 2.13.3

##############################################
Checking Service Quotas Limits on us-east-1...
##############################################

Resource              Quota Name                            Limit    Used     Required    Gap      Suggestion
--------              ----------                            ----     -----    --------    ---      ----------
m5(a).large vCPUs     Running On-Demand Standard instances  716      0        6           514      OK
r5.16xlarge vCPUs     Running On-Demand Standard instances  716      0        192         514      OK
c5.large vCPUs        Running On-Demand Standard instances  716      0        4           514      OK
Elastic IP Addresses  EC2-VPC Elastic IPs                   100      0        3           97       OK
VPCs                  VPCs per Region                       50       1        2           47       OK
NLBs                  Network Load Balancers per Region     50       0        1           49       OK
NAT Gateways          NAT gateways per Availability Zone    100      0        1           99       OK

Note: the listed Instance Types are referring to the same AWS Service Quota.

#######################
# Overall Suggestions #
#######################

Make sure the AWS Account ID <AWS_ACCOUNT_ID> is the one that you want to use for BigAnimal
Make sure the AWS credentials used <AWS_USER_ID>:valerio.delsarto@enterprisedb.com has rights to create IAM Roles and Policies
Highly recommended for EHA: 'Inbound or outbound rules per security group' quota in 'us-east-1' needs to be increased to '200'

Please open a ticket to AWS if need to raise service quota limits.
Open https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html for more info.
Default service quota limits can be found here https://docs.aws.amazon.com/general/latest/gr/aws-general.pdf#aws-service-information.
You can also run aws support create-case help or aws service-quotas request-service-quota-increase help for more examples.
```