### PR TITLE
feat(UPM-24309): updates for contain resource quotas

### DIFF
--- a/gcp/biganimal_GCP_baserole.yaml
+++ b/gcp/biganimal_GCP_baserole.yaml
@@ -337,6 +337,8 @@ includedPermissions:
 - container.replicaSets.update
 - container.replicaSets.updateScale
 - container.replicaSets.updateStatus
+- container.resourceQuotas.get
+- container.resourceQuotas.create
 - container.roleBindings.create
 - container.roleBindings.delete
 - container.roleBindings.get


### PR DESCRIPTION
updating permissions for gcp so that it can run without error with the new updates to flux 

re: https://github.com/fluxcd/flux2/pull/3879