### PR TITLE
fix(UPM-41754): preflight script failed with t3.medium instance type

### DIFF
--- a/aws/biganimal-csp-preflight
+++ b/aws/biganimal-csp-preflight
@@ -203,7 +203,7 @@ function _extract_instancetype_info()
     local class=""
 
     # given "r5b.12xlarge", the regex pattern is (r5b).(12xlarge)
-    if [[ "${instance_type}" =~ ([a-z][0-9][a-z]*).([0-9]*[a-z]*large) ]]; then
+    if [[ "${instance_type}" =~ ([a-z][0-9][a-z]*).([0-9]*[a-z]*large|medium) ]]; then
       class="${BASH_REMATCH[1]}"
       size="${BASH_REMATCH[2]}"
 


### PR DESCRIPTION
Fix the regex in order to allow the usage of t3.medium instance types.